### PR TITLE
Add PhpUnitTestClassRequiresCoversFixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG for PHP CS Fixer: custom fixers
 
+## [Unreleased]
+- Add PhpUnitTestClassRequiresCoversFixer
+
 ## v1.15.0 - *2019-08-19*
 - Add CommentSurroundedBySpacesFixer
 - Add DataProviderReturnTypeFixer

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Build status](https://img.shields.io/travis/kubawerlos/php-cs-fixer-custom-fixers/master.svg)](https://travis-ci.org/kubawerlos/php-cs-fixer-custom-fixers)
 [![Code coverage](https://img.shields.io/coveralls/github/kubawerlos/php-cs-fixer-custom-fixers/master.svg)](https://coveralls.io/github/kubawerlos/php-cs-fixer-custom-fixers?branch=master)
-![Tests](https://img.shields.io/badge/tests-1111-brightgreen.svg)
+![Tests](https://img.shields.io/badge/tests-1145-brightgreen.svg)
 [![Mutation testing badge](https://badge.stryker-mutator.io/github.com/kubawerlos/php-cs-fixer-custom-fixers/master)](https://stryker-mutator.github.io)
 
 A set of custom fixers for [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer).
@@ -320,6 +320,22 @@ PHPUnit's functions `fail`, `markTestIncomplete` and `markTestSkipped` should no
      public function testFoo() {
          $this->markTestSkipped();
 -        return;
+     }
+ }
+```
+
+#### PhpUnitTestClassRequiresCoversFixer
+Test class must have `@covers*` annotation.
+```diff
+ <?php
+ use AcmeCorporation\FooBar;
++/**
++ * @covers \AcmeCorporation\FooBar
++ */
+ class FooBarTest extends TestCase {
+     public function testFoo() {
+         $this->markTestSkipped();
+         return;
      }
  }
 ```

--- a/src/Fixer/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnitTestClassRequiresCoversFixer.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace PhpCsFixerCustomFixers\Fixer;
+
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\DocBlock\Line;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Indicator\PhpUnitTestCaseIndicator;
+use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Kuba Werłos <werlos@gmail.com>
+ */
+final class PhpUnitTestClassRequiresCoversFixer extends AbstractFixer
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Test class must have `@covers*` annotation.',
+            [new CodeSample('<?php
+use AcmeCorporation\FooBar;
+class FooBarTest extends TestCase {
+    public function testFoo() {
+        $this->markTestSkipped();
+        return;
+    }
+}
+')]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_CLASS);
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function getPriority(): int
+    {
+        // must be run before PhpCsFixer\Fixer\PhpUnit\PhpUnitTestClassRequiresCoversFixer
+        return 1;
+    }
+
+    public function fix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $phpUnitTestCaseIndicator = new PhpUnitTestCaseIndicator();
+
+        foreach ($phpUnitTestCaseIndicator->findPhpUnitClasses($tokens) as $indexes) {
+            $this->addRequiresCover($tokens, $indexes[0]);
+        }
+    }
+
+    private function addRequiresCover(Tokens $tokens, int $startIndex): void
+    {
+        /** @var int $classIndex */
+        $classIndex = $tokens->getPrevTokenOfKind($startIndex, [[T_CLASS]]);
+
+        $prevIndex = $tokens->getPrevMeaningfulToken($classIndex);
+
+        // don't add `@covers` annotation for abstract base classes
+        if ($tokens[$prevIndex]->isGivenKind(T_ABSTRACT)) {
+            return;
+        }
+
+        /** @var int $index */
+        $index = $tokens[$prevIndex]->isGivenKind(T_FINAL) ? $prevIndex : $classIndex;
+
+        /** @var string $indent */
+        $indent = $tokens[$index - 1]->isGivenKind(T_WHITESPACE)
+            ? Preg::replace('/^.*\R*/', '', $tokens[$index - 1]->getContent())
+            : '';
+
+        /** @var int $prevIndex */
+        $prevIndex = $tokens->getPrevNonWhitespace($index);
+
+        if ($tokens[$prevIndex]->isGivenKind(T_DOC_COMMENT)) {
+            $docIndex = $prevIndex;
+            $docContent = $tokens[$docIndex]->getContent();
+
+            // ignore one-line phpdocs like `/** foo */`, as there is no place to put new annotations
+            if (\strpos($docContent, "\n") === false) {
+                return;
+            }
+
+            $doc = new DocBlock($docContent);
+
+            // skip if already has annotation
+            if ($doc->getAnnotationsOfType(['covers', 'coversDefaultClass', 'coversNothing']) !== []) {
+                return;
+            }
+        } else {
+            $docIndex = $index;
+            $tokens->insertAt($docIndex, [
+                new Token([T_DOC_COMMENT, \sprintf('/**%s%s */', "\n", $indent)]),
+                new Token([T_WHITESPACE, \sprintf('%s%s', "\n", $indent)]),
+            ]);
+
+            if (!$tokens[$docIndex - 1]->isGivenKind(T_WHITESPACE)) {
+                $extraNewLines = "\n";
+
+                if (!$tokens[$docIndex - 1]->isGivenKind(T_OPEN_TAG)) {
+                    $extraNewLines .= "\n";
+                }
+
+                $tokens->insertAt($docIndex, [
+                    new Token([T_WHITESPACE, $extraNewLines . $indent]),
+                ]);
+                $docIndex++;
+            }
+
+            $doc = new DocBlock($tokens[$docIndex]->getContent());
+        }
+
+        /** @var int $classIndex */
+        $classIndex = $tokens->getPrevTokenOfKind($startIndex + 1, [[T_CLASS]]);
+
+        $lines = $doc->getLines();
+        \array_splice(
+            $lines,
+            \count($lines) - 1,
+            0,
+            [
+                new Line(\sprintf(
+                    '%s * @%s%s',
+                    $indent,
+                    $this->calculateAnnotation($tokens, $classIndex),
+                    "\n"
+                )),
+            ]
+        );
+
+        $tokens[$docIndex] = new Token([T_DOC_COMMENT, \implode('', $lines)]);
+    }
+
+    private function calculateAnnotation(Tokens $tokens, int $classIndex): string
+    {
+        $classNameIndex = $tokens->getNextMeaningfulToken($classIndex);
+        $className = $tokens[$classNameIndex]->getContent();
+
+        foreach ((new NamespaceUsesAnalyzer())->getDeclarationsFromTokens($tokens) as $import) {
+            if ($import->getShortName() . 'Test' === $className) {
+                return 'covers \\' . $import->getFullName();
+            }
+        }
+
+        return 'coversNothing';
+    }
+}

--- a/tests/Fixer/PhpUnitTestClassRequiresCoversFixerTest.php
+++ b/tests/Fixer/PhpUnitTestClassRequiresCoversFixerTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixer;
+
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestClassRequiresCoversFixer as PhpCsFixerPhpUnitTestClassRequiresCoversFixer;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixerCustomFixers\Fixer\PhpUnitTestClassRequiresCoversFixer
+ */
+final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCase
+{
+    public function testPriority(): void
+    {
+        static::assertGreaterThan((new PhpCsFixerPhpUnitTestClassRequiresCoversFixer())->getPriority(), $this->fixer->getPriority());
+    }
+
+    public function testIsRisky(): void
+    {
+        static::assertFalse($this->fixer->isRisky());
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     * @dataProvider providePhpCsFixerFixCases
+     */
+    public function testFix(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases(): iterable
+    {
+        yield [
+            '<?php
+use AcmeCorporation\FooBar;
+/**
+ * @covers \AcmeCorporation\FooBar
+ */
+class FooBarTest extends TestCase {
+    public function testFoo() {
+        $this->markTestSkipped();
+        return;
+    }
+}',
+            '<?php
+use AcmeCorporation\FooBar;
+class FooBarTest extends TestCase {
+    public function testFoo() {
+        $this->markTestSkipped();
+        return;
+    }
+}',
+        ];
+
+        yield [
+            '<?php
+use AcmeCorporation\FooBar;
+/**
+ * @group foo
+ * @covers \AcmeCorporation\FooBar
+ */
+class FooBarTest extends TestCase {
+    public function testFoo() {
+        $this->markTestSkipped();
+        return;
+    }
+}',
+            '<?php
+use AcmeCorporation\FooBar;
+/**
+ * @group foo
+ */
+class FooBarTest extends TestCase {
+    public function testFoo() {
+        $this->markTestSkipped();
+        return;
+    }
+}',
+        ];
+
+        yield [
+            '<?php
+use AcmeCorporation\FooBar;
+
+/**
+ * @covers \AcmeCorporation\FooBar
+ */
+class FooBarTest extends TestCase {
+    public function testFoo() {
+        $this->markTestSkipped();
+        return;
+    }
+}',
+            '<?php
+use AcmeCorporation\FooBar;class FooBarTest extends TestCase {
+    public function testFoo() {
+        $this->markTestSkipped();
+        return;
+    }
+}',
+        ];
+    }
+
+    public function providePhpCsFixerFixCases(): iterable
+    {
+        return [
+            'already with annotation: @covers' => [
+                '<?php
+                    /**
+                     * @covers Foo
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'already with annotation: @coversDefaultClass' => [
+                '<?php
+                    /**
+                     * @coversDefaultClass
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'without docblock #1' => [
+                '<?php
+
+                    /**
+                     * @coversNothing
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'without docblock #2 (class is final)' => [
+                '<?php
+
+                    /**
+                     * @coversNothing
+                     */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'without docblock #2 (class is abstract)' => [
+                '<?php
+                    abstract class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'with docblock but annotation is missing' => [
+                '<?php
+
+                    /**
+                     * Description.
+                     *
+                     * @since v2.2
+                     * @coversNothing
+                     */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    /**
+                     * Description.
+                     *
+                     * @since v2.2
+                     */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'with one-line docblock but annotation is missing' => [
+                '<?php
+
+                    /** Description. */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'with 2-lines docblock but annotation is missing #1' => [
+                '<?php
+
+                    /** Description.
+                     * @coversNothing
+                     */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    /** Description.
+                     */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'with 2-lines docblock but annotation is missing #2' => [
+                '<?php
+
+                    /**
+                     * @coversNothing
+                     * Description. */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    /**
+                     * Description. */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'with comment instead of docblock' => [
+                '<?php
+                    /*
+                     * @covers Foo
+                     */
+                    /**
+                     * @coversNothing
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+                    /*
+                     * @covers Foo
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'not a test class' => [
+                '<?php
+
+                    class Foo {}
+                ',
+            ],
+            'multiple classes in one file' => [
+                '<?php /** */
+
+                    use \PHPUnit\Framework\TestCase;
+
+                    /**
+                     * Foo
+                     * @coversNothing
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+
+                    class Bar {}
+
+                    /**
+                     * @coversNothing
+                     */
+                    class Baz1 extends PHPUnit_Framework_TestCase {}
+
+                    /**
+                     * @coversNothing
+                     */
+                    class Baz2 extends \PHPUnit_Framework_TestCase {}
+
+                    /**
+                     * @coversNothing
+                     */
+                    class Baz3 extends \PHPUnit\Framework\TestCase {}
+
+                    /**
+                     * @coversNothing
+                     */
+                    class Baz4 extends TestCase {}
+                ',
+                '<?php /** */
+
+                    use \PHPUnit\Framework\TestCase;
+
+                    /**
+                     * Foo
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+
+                    class Bar {}
+
+                    class Baz1 extends PHPUnit_Framework_TestCase {}
+
+                    class Baz2 extends \PHPUnit_Framework_TestCase {}
+
+                    class Baz3 extends \PHPUnit\Framework\TestCase {}
+
+                    class Baz4 extends TestCase {}
+                ',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
@keradus are you OK with this? I've copied original `PhpUnitTestClassRequiresCoversFixer` (and tests) made by you and extended in function `calculateAnnotation`.

What do you think about extending original fixer with a boolean option `try_to_calculate_covered_class`?