### PR TITLE
Handles multiple switch statements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Build status](https://img.shields.io/travis/kubawerlos/php-cs-fixer-custom-fixers/master.svg)](https://travis-ci.org/kubawerlos/php-cs-fixer-custom-fixers)
 [![Code coverage](https://img.shields.io/coveralls/github/kubawerlos/php-cs-fixer-custom-fixers/master.svg)](https://coveralls.io/github/kubawerlos/php-cs-fixer-custom-fixers?branch=master)
-![Tests](https://img.shields.io/badge/tests-1358-brightgreen.svg)
+![Tests](https://img.shields.io/badge/tests-1359-brightgreen.svg)
 [![Mutation testing badge](https://badge.stryker-mutator.io/github.com/kubawerlos/php-cs-fixer-custom-fixers/master)](https://stryker-mutator.github.io)
 [![Psalm type coverage](https://shepherd.dev/github/kubawerlos/php-cs-fixer-custom-fixers/coverage.svg)](https://shepherd.dev/github/kubawerlos/php-cs-fixer-custom-fixers)
 

--- a/src/Fixer/OperatorLinebreakFixer.php
+++ b/src/Fixer/OperatorLinebreakFixer.php
@@ -135,7 +135,7 @@ function foo() {
         $indices = [];
         for ($index = $tokens->count() - 1; $index > 0; $index--) {
             if ($tokens[$index]->isGivenKind(T_SWITCH)) {
-                $indices += $this->getCasesColonsForSwitch($tokens, $index);
+                $indices = \array_merge($indices, $this->getCasesColonsForSwitch($tokens, $index));
             }
         }
 

--- a/tests/Fixer/OperatorLinebreakFixerTest.php
+++ b/tests/Fixer/OperatorLinebreakFixerTest.php
@@ -189,6 +189,22 @@ return $foo
             null,
             ['position' => 'end'],
         ];
+
+        yield 'multiple switches' => [
+            '<?php
+                switch ($foo) {
+                   case 1:
+                      break;
+                   case 2:
+                      break;
+                }
+                switch($bar) {
+                   case 1:
+                      break;
+                   case 2:
+                      break;
+                }',
+        ];
     }
 
     private function pairs(): iterable


### PR DESCRIPTION
`OperatorLinebreakFixer` was not behaving correctly when multiple `switch` statements were present in a file.

Fixing:

```php
switch ($foo) {
   case 1:
      break;
   case 2:
      break;
}
switch($bar) {
   case 1:
      break;
   case 2:
      break;
}
```

resulted in:

```php
switch ($foo) {
   case 1
      :break;
   case 2:
      :break;
}
switch($bar) {
   case 1:
      break;
   case 2:
      break;
}
```

This was due to merging excluded `T_SWITCH` tokens indices arrays incorrectly.

I've tried to add test case for this, but can't figure out how to reproduce this via test case.

If You have any idea, let me know. I'll update my PR.