### PR TITLE
Add DataProviderStaticFixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Update PHP CS Fixer to v2.16
+- Add DataProviderStaticFixer
 - Deprecate SingleLineThrowFixer
 
 ## v1.16.0 - *2019-10-24*

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Build status](https://img.shields.io/travis/kubawerlos/php-cs-fixer-custom-fixers/master.svg)](https://travis-ci.org/kubawerlos/php-cs-fixer-custom-fixers)
 [![Code coverage](https://img.shields.io/coveralls/github/kubawerlos/php-cs-fixer-custom-fixers/master.svg)](https://coveralls.io/github/kubawerlos/php-cs-fixer-custom-fixers?branch=master)
-![Tests](https://img.shields.io/badge/tests-1480-brightgreen.svg)
+![Tests](https://img.shields.io/badge/tests-1500-brightgreen.svg)
 [![Mutation testing badge](https://badge.stryker-mutator.io/github.com/kubawerlos/php-cs-fixer-custom-fixers/master)](https://stryker-mutator.github.io)
 [![Psalm type coverage](https://shepherd.dev/github/kubawerlos/php-cs-fixer-custom-fixers/coverage.svg)](https://shepherd.dev/github/kubawerlos/php-cs-fixer-custom-fixers)
 
@@ -73,6 +73,20 @@ Return type of data provider must be `iterable`.
      public function testHappyPath() {}
 -    public function provideHappyPathCases(): array {}
 +    public function provideHappyPathCases(): iterable {}
+ }
+```
+
+#### DataProviderStaticFixer
+Data provider must be static.
+```diff
+ <?php
+ class FooTest extends TestCase {
+     /**
+      * @dataProvider provideHappyPathCases
+      */
+     public function testHappyPath() {}
+-    public function provideHappyPathCases() {}
++    public static function provideHappyPathCases() {}
  }
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Build status](https://img.shields.io/travis/kubawerlos/php-cs-fixer-custom-fixers/master.svg)](https://travis-ci.org/kubawerlos/php-cs-fixer-custom-fixers)
 [![Code coverage](https://img.shields.io/coveralls/github/kubawerlos/php-cs-fixer-custom-fixers/master.svg)](https://coveralls.io/github/kubawerlos/php-cs-fixer-custom-fixers?branch=master)
-![Tests](https://img.shields.io/badge/tests-1500-brightgreen.svg)
+![Tests](https://img.shields.io/badge/tests-1547-brightgreen.svg)
 [![Mutation testing badge](https://badge.stryker-mutator.io/github.com/kubawerlos/php-cs-fixer-custom-fixers/master)](https://stryker-mutator.github.io)
 [![Psalm type coverage](https://shepherd.dev/github/kubawerlos/php-cs-fixer-custom-fixers/coverage.svg)](https://shepherd.dev/github/kubawerlos/php-cs-fixer-custom-fixers)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Build status](https://img.shields.io/travis/kubawerlos/php-cs-fixer-custom-fixers/master.svg)](https://travis-ci.org/kubawerlos/php-cs-fixer-custom-fixers)
 [![Code coverage](https://img.shields.io/coveralls/github/kubawerlos/php-cs-fixer-custom-fixers/master.svg)](https://coveralls.io/github/kubawerlos/php-cs-fixer-custom-fixers?branch=master)
-![Tests](https://img.shields.io/badge/tests-1547-brightgreen.svg)
+![Tests](https://img.shields.io/badge/tests-1548-brightgreen.svg)
 [![Mutation testing badge](https://badge.stryker-mutator.io/github.com/kubawerlos/php-cs-fixer-custom-fixers/master)](https://stryker-mutator.github.io)
 [![Psalm type coverage](https://shepherd.dev/github/kubawerlos/php-cs-fixer-custom-fixers/coverage.svg)](https://shepherd.dev/github/kubawerlos/php-cs-fixer-custom-fixers)
 

--- a/src/Fixer/DataProviderNameFixer.php
+++ b/src/Fixer/DataProviderNameFixer.php
@@ -47,7 +47,7 @@ class FooTest extends TestCase {
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_DOC_COMMENT, T_EXTENDS, T_FUNCTION, T_STRING]);
     }
 
     public function isRisky(): bool

--- a/src/Fixer/DataProviderReturnTypeFixer.php
+++ b/src/Fixer/DataProviderReturnTypeFixer.php
@@ -49,7 +49,7 @@ class FooTest extends TestCase {
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_DOC_COMMENT, T_EXTENDS, T_FUNCTION, T_STRING]);
     }
 
     public function isRisky(): bool

--- a/src/Fixer/DataProviderStaticFixer.php
+++ b/src/Fixer/DataProviderStaticFixer.php
@@ -45,7 +45,7 @@ class FooTest extends TestCase {
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_DOC_COMMENT, T_EXTENDS, T_FUNCTION, T_STRING]);
     }
 
     public function isRisky(): bool

--- a/src/Fixer/DataProviderStaticFixer.php
+++ b/src/Fixer/DataProviderStaticFixer.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace PhpCsFixerCustomFixers\Fixer;
+
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Indicator\PhpUnitTestCaseIndicator;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixerCustomFixers\Analyzer\DataProviderAnalyzer;
+
+final class DataProviderStaticFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Data provider must be static.',
+            [
+                new CodeSample(
+                    '<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideHappyPathCases
+     */
+    public function testHappyPath() {}
+    public function provideHappyPathCases() {}
+}
+'
+                ),
+            ]
+        );
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function fix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $phpUnitTestCaseIndicator = new PhpUnitTestCaseIndicator();
+
+        /** @var int[] $indices */
+        foreach ($phpUnitTestCaseIndicator->findPhpUnitClasses($tokens) as $indices) {
+            $this->fixStatic($tokens, $indices[0], $indices[1]);
+        }
+    }
+
+    private function fixStatic(Tokens $tokens, int $startIndex, int $endIndex): void
+    {
+        $dataProviderAnalyzer = new DataProviderAnalyzer();
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        foreach (\array_reverse($dataProviderAnalyzer->getDataProviders($tokens, $startIndex, $endIndex)) as $dataProviderAnalysis) {
+            /** @var int $methodStartIndex */
+            $methodStartIndex = $tokens->getNextTokenOfKind($dataProviderAnalysis->getNameIndex(), ['{']);
+
+            $methodEndIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $methodStartIndex);
+
+            if ($tokens->findSequence([[T_VARIABLE, '$this']], $methodStartIndex, $methodEndIndex) !== null) {
+                continue;
+            }
+
+            /** @var int $functionIndex */
+            $functionIndex = $tokens->getPrevTokenOfKind($dataProviderAnalysis->getNameIndex(), [[T_FUNCTION]]);
+
+            $methodAttributes = $tokensAnalyzer->getMethodAttributes($functionIndex);
+            if ($methodAttributes['static'] !== false) {
+                continue;
+            }
+
+            $tokens->insertAt(
+                $functionIndex,
+                [new Token([T_STATIC, 'static']), new Token([T_WHITESPACE, ' '])]
+            );
+        }
+    }
+}

--- a/src/Fixer/PhpUnitNoUselessReturnFixer.php
+++ b/src/Fixer/PhpUnitNoUselessReturnFixer.php
@@ -49,7 +49,7 @@ class FooTest extends TestCase {
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isTokenKindFound(T_STRING);
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_EXTENDS, T_FUNCTION, T_STRING, T_RETURN]);
     }
 
     public function isRisky(): bool

--- a/tests/Analyzer/ReferenceAnalyzerTest.php
+++ b/tests/Analyzer/ReferenceAnalyzerTest.php
@@ -48,7 +48,7 @@ final class ReferenceAnalyzerTest extends TestCase
         $this->doTestCode(false, $code);
     }
 
-    public function provideReferenceCases(): iterable
+    public static function provideReferenceCases(): iterable
     {
         yield ['<?php $foo =& $bar;'];
         yield ['<?php $foo =& find_var($bar);'];
@@ -73,7 +73,7 @@ class Foo {
         yield ['<?php foreach($foos as $key => &$foo) {}'];
     }
 
-    public function provideNonReferenceCases(): iterable
+    public static function provideNonReferenceCases(): iterable
     {
         yield ['<?php $foo & $bar;'];
         yield ['<?php FOO & $bar;'];

--- a/tests/Analyzer/SwitchAnalyzerTest.php
+++ b/tests/Analyzer/SwitchAnalyzerTest.php
@@ -38,7 +38,7 @@ final class SwitchAnalyzerTest extends TestCase
         static::assertSame(\serialize($expected), \serialize(($analyzer->getSwitchAnalysis($tokens, $index))));
     }
 
-    public function provideGettingSwitchAnalysisCases(): iterable
+    public static function provideGettingSwitchAnalysisCases(): iterable
     {
         yield 'two cases' => [
             new SwitchAnalysis(7, 29, [new CaseAnalysis(12), new CaseAnalysis(22)]),

--- a/tests/AutoReview/SrcCodeTest.php
+++ b/tests/AutoReview/SrcCodeTest.php
@@ -72,7 +72,7 @@ final class SrcCodeTest extends TestCase
         );
     }
 
-    public function provideFixerCases(): iterable
+    public static function provideFixerCases(): iterable
     {
         return \array_map(
             static function (FixerInterface $fixer): array {
@@ -120,7 +120,7 @@ final class SrcCodeTest extends TestCase
         static::assertNotContains('preg_split', $strings, $message);
     }
 
-    public function provideThereIsNoPregFunctionUsedDirectlyCases(): iterable
+    public static function provideThereIsNoPregFunctionUsedDirectlyCases(): iterable
     {
         $finder = Finder::create()
             ->files()

--- a/tests/AutoReview/TestsCodeTest.php
+++ b/tests/AutoReview/TestsCodeTest.php
@@ -38,7 +38,17 @@ final class TestsCodeTest extends TestCase
         static::assertSame('iterable', $reflectionMethod->getReturnType()->getName());
     }
 
-    public function provideDataProviderCases(): iterable
+    /**
+     * @dataProvider provideDataProviderCases
+     */
+    public function testDataProviderIsStatic(string $dataProviderName, string $className): void
+    {
+        $reflectionMethod = new \ReflectionMethod($className, $dataProviderName);
+
+        static::assertTrue($reflectionMethod->isStatic());
+    }
+
+    public static function provideDataProviderCases(): iterable
     {
         static $dataProviders;
 
@@ -57,7 +67,7 @@ final class TestsCodeTest extends TestCase
                     $className .= '\\' . \str_replace('/', '\\', $file->getRelativePath());
                 }
                 $className .= '\\' . $file->getBasename('.php');
-                foreach ($this->getDataProviderMethodNames($className) as $dataProviderName) {
+                foreach (static::getDataProviderMethodNames($className) as $dataProviderName) {
                     $dataProviders[\sprintf('%s::%s', $className, $dataProviderName)] = [$dataProviderName, $className];
                 }
             }
@@ -71,7 +81,7 @@ final class TestsCodeTest extends TestCase
     /**
      * @return string[]
      */
-    private function getDataProviderMethodNames(string $className): array
+    private static function getDataProviderMethodNames(string $className): array
     {
         $reflection = new \ReflectionClass($className);
 

--- a/tests/Fixer/CommentSurroundedBySpacesFixerTest.php
+++ b/tests/Fixer/CommentSurroundedBySpacesFixerTest.php
@@ -24,7 +24,7 @@ final class CommentSurroundedBySpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php $a; //'];
         yield ['<?php $a; ////'];

--- a/tests/Fixer/DataProviderNameFixerTest.php
+++ b/tests/Fixer/DataProviderNameFixerTest.php
@@ -24,7 +24,7 @@ final class DataProviderNameFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'data provider correctly named' => [
             '<?php

--- a/tests/Fixer/DataProviderReturnTypeFixerTest.php
+++ b/tests/Fixer/DataProviderReturnTypeFixerTest.php
@@ -24,7 +24,7 @@ final class DataProviderReturnTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'data provider with iterable return type' => [
             '<?php

--- a/tests/Fixer/DataProviderStaticFixerTest.php
+++ b/tests/Fixer/DataProviderStaticFixerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Fixer;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixerCustomFixers\Fixer\DataProviderStaticFixer
+ */
+final class DataProviderStaticFixerTest extends AbstractFixerTestCase
+{
+    public function testIsRisky(): void
+    {
+        static::assertFalse($this->fixer->isRisky());
+    }
+
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixCases(): iterable
+    {
+        yield 'do not fix data provider containing dynamic calls' => [
+            '<?php
+class FooTest extends TestCase {
+    /** 
+     * @dataProvider provideFoo1Cases
+     */
+    public function testFoo1() {}
+    public function provideFoo1Cases() { $this->init(); }
+}',
+        ];
+
+        yield 'fix single data provider' => [
+            '<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideFooCases
+     */
+    public function testFoo() {}
+    public static function provideFooCases() { $x->getData(); }
+}',
+            '<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideFooCases
+     */
+    public function testFoo() {}
+    public function provideFooCases() { $x->getData(); }
+}',
+        ];
+
+        yield 'fix multiple data provider' => [
+            '<?php
+class FooTest extends TestCase {
+    /** @dataProvider provider1 */
+    public function testFoo1() {}
+    /** @dataProvider provider2 */
+    public function testFoo2() {}
+    /** @dataProvider provider3 */
+    public function testFoo13() {}
+    public static function provider1() {}
+    public function provider2() { $this->init(); }
+    public static function provider3() {}
+}',
+            '<?php
+class FooTest extends TestCase {
+    /** @dataProvider provider1 */
+    public function testFoo1() {}
+    /** @dataProvider provider2 */
+    public function testFoo2() {}
+    /** @dataProvider provider3 */
+    public function testFoo13() {}
+    public function provider1() {}
+    public function provider2() { $this->init(); }
+    public static function provider3() {}
+}',
+        ];
+    }
+}

--- a/tests/Fixer/DataProviderStaticFixerTest.php
+++ b/tests/Fixer/DataProviderStaticFixerTest.php
@@ -26,7 +26,7 @@ final class DataProviderStaticFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        yield 'do not fix data provider containing dynamic calls' => [
+        yield 'do not fix when containing dynamic calls' => [
             '<?php
 class FooTest extends TestCase {
     /** 
@@ -37,7 +37,7 @@ class FooTest extends TestCase {
 }',
         ];
 
-        yield 'fix single data provider' => [
+        yield 'fix single' => [
             '<?php
 class FooTest extends TestCase {
     /**
@@ -56,7 +56,7 @@ class FooTest extends TestCase {
 }',
         ];
 
-        yield 'fix multiple data provider' => [
+        yield 'fix multiple' => [
             '<?php
 class FooTest extends TestCase {
     /** @dataProvider provider1 */
@@ -80,6 +80,29 @@ class FooTest extends TestCase {
     public function provider1() {}
     public function provider2() { $this->init(); }
     public static function provider3() {}
+}',
+        ];
+
+        yield 'fix with multilines' => [
+            '<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideFooCases
+     */
+    public function testFoo() {}
+    public
+        static function
+            provideFooCases() { $x->getData(); }
+}',
+            '<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideFooCases
+     */
+    public function testFoo() {}
+    public
+        function
+            provideFooCases() { $x->getData(); }
 }',
         ];
     }

--- a/tests/Fixer/ImplodeCallFixerTest.php
+++ b/tests/Fixer/ImplodeCallFixerTest.php
@@ -29,7 +29,7 @@ final class ImplodeCallFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ["<?php implode('', [1,2,3]);"];
         yield ['<?php implode("", $foo);'];

--- a/tests/Fixer/InternalClassCasingFixerTest.php
+++ b/tests/Fixer/InternalClassCasingFixerTest.php
@@ -24,7 +24,7 @@ final class InternalClassCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php class STDCLASS {};'];
         yield ['<?php class STDCLASS { use EXCEPTION; };'];

--- a/tests/Fixer/MultilineCommentOpeningClosingAloneFixerTest.php
+++ b/tests/Fixer/MultilineCommentOpeningClosingAloneFixerTest.php
@@ -24,7 +24,7 @@ final class MultilineCommentOpeningClosingAloneFixerTest extends AbstractFixerTe
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php /* Foo */'];
         yield ['<?php /** Foo */'];

--- a/tests/Fixer/NoCommentedOutCodeFixerTest.php
+++ b/tests/Fixer/NoCommentedOutCodeFixerTest.php
@@ -24,7 +24,7 @@ final class NoCommentedOutCodeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php // do not remove me'];
         yield ['<?php # do not remove me'];

--- a/tests/Fixer/NoDoctrineMigrationsGeneratedCommentFixerTest.php
+++ b/tests/Fixer/NoDoctrineMigrationsGeneratedCommentFixerTest.php
@@ -24,7 +24,7 @@ final class NoDoctrineMigrationsGeneratedCommentFixerTest extends AbstractFixerT
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'do not remove when comments were changed' => [
             '<?php

--- a/tests/Fixer/NoDuplicatedImportsFixerTest.php
+++ b/tests/Fixer/NoDuplicatedImportsFixerTest.php
@@ -24,7 +24,7 @@ final class NoDuplicatedImportsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/NoImportFromGlobalNamespaceFixerTest.php
+++ b/tests/Fixer/NoImportFromGlobalNamespaceFixerTest.php
@@ -24,7 +24,7 @@ final class NoImportFromGlobalNamespaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php
 namespace Foo;

--- a/tests/Fixer/NoLeadingSlashInGlobalNamespaceFixerTest.php
+++ b/tests/Fixer/NoLeadingSlashInGlobalNamespaceFixerTest.php
@@ -24,7 +24,7 @@ final class NoLeadingSlashInGlobalNamespaceFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php $foo = new Bar();',

--- a/tests/Fixer/NoNullableBooleanTypeFixerTest.php
+++ b/tests/Fixer/NoNullableBooleanTypeFixerTest.php
@@ -24,7 +24,7 @@ final class NoNullableBooleanTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php function foo(bool $b) {}',

--- a/tests/Fixer/NoPhpStormGeneratedCommentFixerTest.php
+++ b/tests/Fixer/NoPhpStormGeneratedCommentFixerTest.php
@@ -24,7 +24,7 @@ final class NoPhpStormGeneratedCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/NoReferenceInFunctionDefinitionFixerTest.php
+++ b/tests/Fixer/NoReferenceInFunctionDefinitionFixerTest.php
@@ -24,7 +24,7 @@ final class NoReferenceInFunctionDefinitionFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php function foo($x) {}',

--- a/tests/Fixer/NoTwoConsecutiveEmptyLinesFixerTest.php
+++ b/tests/Fixer/NoTwoConsecutiveEmptyLinesFixerTest.php
@@ -29,7 +29,7 @@ final class NoTwoConsecutiveEmptyLinesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/NoUnneededConcatenationFixerTest.php
+++ b/tests/Fixer/NoUnneededConcatenationFixerTest.php
@@ -24,7 +24,7 @@ final class NoUnneededConcatenationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php $foo. "bar";'];
         yield ['<?php "foo" .$bar;'];

--- a/tests/Fixer/NoUselessClassCommentFixerTest.php
+++ b/tests/Fixer/NoUselessClassCommentFixerTest.php
@@ -29,7 +29,7 @@ final class NoUselessClassCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/NoUselessCommentFixerTest.php
+++ b/tests/Fixer/NoUselessCommentFixerTest.php
@@ -24,7 +24,7 @@ final class NoUselessCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/NoUselessConstructorCommentFixerTest.php
+++ b/tests/Fixer/NoUselessConstructorCommentFixerTest.php
@@ -29,7 +29,7 @@ final class NoUselessConstructorCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/NoUselessDoctrineRepositoryCommentFixerTest.php
+++ b/tests/Fixer/NoUselessDoctrineRepositoryCommentFixerTest.php
@@ -24,7 +24,7 @@ final class NoUselessDoctrineRepositoryCommentFixerTest extends AbstractFixerTes
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/NoUselessSprintfFixerTest.php
+++ b/tests/Fixer/NoUselessSprintfFixerTest.php
@@ -24,7 +24,7 @@ final class NoUselessSprintfFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php $foo = sprintf($format, $value);'];
         yield ['<?php $foo = sprintf("My name is %s.", "Earl");'];

--- a/tests/Fixer/NullableParamStyleFixerTest.php
+++ b/tests/Fixer/NullableParamStyleFixerTest.php
@@ -31,7 +31,7 @@ final class NullableParamStyleFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input, $configuration);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php function foo($x = null) {}'];
         yield ['<?php function foo(int $x, ?int $y) {}'];

--- a/tests/Fixer/OperatorLinebreakFixerTest.php
+++ b/tests/Fixer/OperatorLinebreakFixerTest.php
@@ -38,13 +38,11 @@ final class OperatorLinebreakFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input, $configuration);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
-        foreach ($this->pairs() as $key => $value) {
+        foreach (static::pairs() as $key => $value) {
             yield \sprintf('%s when position is "beginning"', $key) => $value;
-        }
 
-        foreach ($this->pairs() as $key => $value) {
             yield \sprintf('%s when position is "end"', $key) => [
                 $value[1],
                 $value[0],
@@ -198,7 +196,7 @@ return $foo
         ];
     }
 
-    private function pairs(): iterable
+    private static function pairs(): iterable
     {
         yield 'handle equal sign' => [
             '<?php

--- a/tests/Fixer/PhpUnitNoUselessReturnFixerTest.php
+++ b/tests/Fixer/PhpUnitNoUselessReturnFixerTest.php
@@ -24,7 +24,7 @@ final class PhpUnitNoUselessReturnFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         return \array_map(
             static function (array $args): array {
@@ -40,11 +40,11 @@ class FooTest extends TestCase {
                     $args
                 );
             },
-            \iterator_to_array($this->getFixCases())
+            \iterator_to_array(static::getFixCases())
         );
     }
 
-    private function getFixCases(): iterable
+    private static function getFixCases(): iterable
     {
         yield ['$this->markTestSkipped = true;'];
 

--- a/tests/Fixer/PhpdocNoIncorrectVarAnnotationFixerTest.php
+++ b/tests/Fixer/PhpdocNoIncorrectVarAnnotationFixerTest.php
@@ -24,7 +24,7 @@ final class PhpdocNoIncorrectVarAnnotationFixerTest extends AbstractFixerTestCas
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/PhpdocNoSuperfluousParamFixerTest.php
+++ b/tests/Fixer/PhpdocNoSuperfluousParamFixerTest.php
@@ -24,7 +24,7 @@ final class PhpdocNoSuperfluousParamFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php
 /**

--- a/tests/Fixer/PhpdocOnlyAllowedAnnotationsFixerTest.php
+++ b/tests/Fixer/PhpdocOnlyAllowedAnnotationsFixerTest.php
@@ -31,7 +31,7 @@ final class PhpdocOnlyAllowedAnnotationsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input, $configuration);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/PhpdocParamOrderFixerTest.php
+++ b/tests/Fixer/PhpdocParamOrderFixerTest.php
@@ -24,7 +24,7 @@ final class PhpdocParamOrderFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/PhpdocParamTypeFixerTest.php
+++ b/tests/Fixer/PhpdocParamTypeFixerTest.php
@@ -24,7 +24,7 @@ final class PhpdocParamTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/PhpdocSelfAccessorFixerTest.php
+++ b/tests/Fixer/PhpdocSelfAccessorFixerTest.php
@@ -24,7 +24,7 @@ final class PhpdocSelfAccessorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [ // no namespace - do not change
             '<?php

--- a/tests/Fixer/PhpdocSingleLineVarFixerTest.php
+++ b/tests/Fixer/PhpdocSingleLineVarFixerTest.php
@@ -24,7 +24,7 @@ final class PhpdocSingleLineVarFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [ // Wrong annotation
             '<?php

--- a/tests/Fixer/PhpdocVarAnnotationCorrectOrderFixerTest.php
+++ b/tests/Fixer/PhpdocVarAnnotationCorrectOrderFixerTest.php
@@ -29,7 +29,7 @@ final class PhpdocVarAnnotationCorrectOrderFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [ // It's @param, we care only about @var
             '<?php

--- a/tests/Fixer/SingleLineThrowFixerTest.php
+++ b/tests/Fixer/SingleLineThrowFixerTest.php
@@ -29,7 +29,7 @@ final class SingleLineThrowFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php throw new Exception; foo(
                     "Foo"

--- a/tests/Fixer/SingleSpaceAfterStatementFixerTest.php
+++ b/tests/Fixer/SingleSpaceAfterStatementFixerTest.php
@@ -113,7 +113,7 @@ interface    FooInterface {
         $this->doTest($expected, $input, $configuration);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php echo 1; array(1, 2, 3);'];
         yield ['<?php echo 1; foo(2);'];
@@ -287,7 +287,7 @@ do    {
         );
     }
 
-    public function provideTokenIsUsefulCases(): iterable
+    public static function provideTokenIsUsefulCases(): iterable
     {
         $fixer = new SingleSpaceAfterStatementFixer();
         $reflection = new \ReflectionClass($fixer);

--- a/tests/Fixer/SingleSpaceBeforeStatementFixerTest.php
+++ b/tests/Fixer/SingleSpaceBeforeStatementFixerTest.php
@@ -24,7 +24,7 @@ final class SingleSpaceBeforeStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php $isNotFoo = !require "foo.php";'];
         yield ['<?php foo(new stdClass());'];

--- a/tests/FixersTest.php
+++ b/tests/FixersTest.php
@@ -35,7 +35,7 @@ final class FixersTest extends TestCase
         static::assertContains($fixer->getName(), $this->fixerNamesFromCollection());
     }
 
-    public function provideFixerIsInCollectionCases(): iterable
+    public static function provideFixerIsInCollectionCases(): iterable
     {
         return \array_map(
             static function (SplFileInfo $fileInfo): array {

--- a/tests/PriorityTest.php
+++ b/tests/PriorityTest.php
@@ -112,7 +112,7 @@ final class PriorityTest extends TestCase
         static::assertSame($sorted, $cases);
     }
 
-    public function providePriorityCases(): iterable
+    public static function providePriorityCases(): iterable
     {
         yield [
             new CommentSurroundedBySpacesFixer(),

--- a/tests/TokenRemoverTest.php
+++ b/tests/TokenRemoverTest.php
@@ -38,7 +38,7 @@ final class TokenRemoverTest extends TestCase
         static::assertTokens(Tokens::fromCode($expected), $tokens);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'after open tag' => [
             '<?php


### PR DESCRIPTION
Motivation: when data provider is NOT static PHPUnit [creates](https://github.com/sebastianbergmann/phpunit/blob/8.4.3/src/Util/Annotation/DocBlock.php#L447) unnecessary object - only to retrieve data.