### PR TITLE
Handle multiple PHPUnit versions

### DIFF
--- a/tests/AssertRegExpTrait.php
+++ b/tests/AssertRegExpTrait.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Tests;
 
+/**
+ * @internal
+ */
 trait AssertRegExpTrait
 {
     public static function assertRegExp(string $pattern, string $string, string $message = ''): void

--- a/tests/AssertRegExpTrait.php
+++ b/tests/AssertRegExpTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer: custom fixers.
+ *
+ * (c) 2018-2020 Kuba Werłos
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests;
+
+trait AssertRegExpTrait
+{
+    public static function assertRegExp(string $pattern, string $string, string $message = ''): void
+    {
+        if (\method_exists(self::class, 'assertMatchesRegularExpression')) {
+            self::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            parent::assertRegExp($pattern, $string, $message);
+        }
+    }
+
+    public static function assertNotRegExp(string $pattern, string $string, string $message = ''): void
+    {
+        if (\method_exists(self::class, 'assertDoesNotMatchRegularExpression')) {
+            self::assertDoesNotMatchRegularExpression($pattern, $string, $message);
+        } else {
+            parent::assertNotRegExp($pattern, $string, $message);
+        }
+    }
+}

--- a/tests/AutoReview/TestsCodeTest.php
+++ b/tests/AutoReview/TestsCodeTest.php
@@ -17,6 +17,7 @@ use PhpCsFixer\DocBlock\DocBlock;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
+use Tests\AssertRegExpTrait;
 
 /**
  * @internal
@@ -25,6 +26,8 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 final class TestsCodeTest extends TestCase
 {
+    use AssertRegExpTrait;
+
     /**
      * @dataProvider provideDataProviderCases
      */

--- a/tests/Fixer/AbstractFixerTestCase.php
+++ b/tests/Fixer/AbstractFixerTestCase.php
@@ -19,12 +19,14 @@ use PhpCsFixer\Linter\TokenizerLinter;
 use PhpCsFixer\Tests\Test\Assert\AssertTokensTrait;
 use PhpCsFixer\Tokenizer\Tokens;
 use PHPUnit\Framework\TestCase;
+use Tests\AssertRegExpTrait;
 
 /**
  * @internal
  */
 abstract class AbstractFixerTestCase extends TestCase
 {
+    use AssertRegExpTrait;
     use AssertTokensTrait;
 
     /** @var DefinedFixerInterface */


### PR DESCRIPTION
- hides PHPUnit 9 deprecations
- needed for PHPUnit 10

Uses new `assertMatchesRegularExpression` and `assertDoesNotMatchRegularExpression` when they are available.