### PR TITLE
Mention `mb_strlen` with `NoUselessStrlenFixer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Function `sprintf` without parameters should not be used.
 ```
 
 #### NoUselessStrlenFixer
-Function `strlen` should not be used when compared to 0.
+Function `strlen` (or `mb_strlen`) should not be used when compared to 0.
   *Risky: when the function `strlen` is overridden.*
 ```diff
  <?php

--- a/src/Fixer/NoUselessStrlenFixer.php
+++ b/src/Fixer/NoUselessStrlenFixer.php
@@ -26,7 +26,7 @@ final class NoUselessStrlenFixer extends AbstractFixer
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Function `strlen` should not be used when compared to 0.',
+            'Function `strlen` (or `mb_strlen`) should not be used when compared to 0.',
             [
                 new CodeSample(
                     '<?php


### PR DESCRIPTION
I noticed the new `NoUselessStrlenFixer` and wondered if it'd work with `mb_strlen` also.

I guessed it would (and [checked the code](https://github.com/kubawerlos/php-cs-fixer-custom-fixers/pull/335/files#diff-8fe1808a682d293c6c45b862a64da353R67)), so thought it'd be helpful to note here.