### PR TITLE
False positive on PHP 8.0 attribute style comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest stable version](https://img.shields.io/packagist/v/kubawerlos/php-cs-fixer-custom-fixers.svg?label=current%20version)](https://packagist.org/packages/kubawerlos/php-cs-fixer-custom-fixers)
 [![PHP version](https://img.shields.io/packagist/php-v/kubawerlos/php-cs-fixer-custom-fixers.svg)](https://php.net)
 [![License](https://img.shields.io/github/license/kubawerlos/php-cs-fixer-custom-fixers.svg)](LICENSE)
-![Tests](https://img.shields.io/badge/tests-2985-brightgreen.svg)
+![Tests](https://img.shields.io/badge/tests-2987-brightgreen.svg)
 [![Downloads](https://img.shields.io/packagist/dt/kubawerlos/php-cs-fixer-custom-fixers.svg)](https://packagist.org/packages/kubawerlos/php-cs-fixer-custom-fixers)
 
 [![CI Status](https://github.com/kubawerlos/php-cs-fixer-custom-fixers/workflows/CI/badge.svg?branch=main&event=push)](https://github.com/kubawerlos/php-cs-fixer-custom-fixers/actions)

--- a/src/Fixer/CommentSurroundedBySpacesFixer.php
+++ b/src/Fixer/CommentSurroundedBySpacesFixer.php
@@ -61,7 +61,7 @@ final class CommentSurroundedBySpacesFixer extends AbstractFixer
             /** @var string $newContent */
             $newContent = Preg::replace(
                 [
-                    '/^(\/\/|#|\/\*+)((?!(?:\/|\*|\h)).+)$/',
+                    '/^(\/\/|#(?!\[)|\/\*+)((?!(?:\/|\*|\h)).+)$/',
                     '/^(.+(?<!(?:\/|\*|\h)))(\*+\/)$/',
                 ],
                 '$1 $2',

--- a/tests/Fixer/CommentSurroundedBySpacesFixerTest.php
+++ b/tests/Fixer/CommentSurroundedBySpacesFixerTest.php
@@ -70,6 +70,15 @@ final class CommentSurroundedBySpacesFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
+            '<?php $a; #',
+        ];
+
+        yield [
+            '<?php #[\ReturnTypeWillChange]
+              function doFoo() {}',
+        ];
+
+        yield [
             '<?php $a; /* foo */',
             '<?php $a; /*foo */',
         ];


### PR DESCRIPTION
Inserting a space character after "#" single-line comment start is causing
disruption for comments that represent a PHP forward compatible PHP 8.0
attribute comment.

Code not tokenized as PHP 8.0+ have this as a single line comment
(T_COMMENT) and as the notation has been designed forward compatible, a
comment fixer introducing the space is much likely a false positive:

    #[\ReturnTypeWillChange]

    # [\ReturnTypeWillChange]

Change is to *not* insert the space when "[" <U005B> LEFT SQUARE BRACKET
follows "#" <U0023> NUMBER SIGN for the CommentSurroundedBySpacesFixer[1].

[1]: \PhpCsFixerCustomFixers\Fixer\CommentSurroundedBySpacesFixer