### PR TITLE
Allow symfony/finder:^6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-filter": "*",
         "ext-tokenizer": "*",
         "friendsofphp/php-cs-fixer": "^3.1.0",
-        "symfony/finder": "^3.0 || ^4.0 || ^5.0"
+        "symfony/finder": "^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.3 || ^9.1.1"


### PR DESCRIPTION
Dropping support for `v3` is not really BC break as it was already impossible to install that version due to [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.1.0/composer.json#L27) requirements.