### PR TITLE
Over-Eager Stringable Matching

### DIFF
--- a/tests/Fixer/StringableInterfaceFixerTest.php
+++ b/tests/Fixer/StringableInterfaceFixerTest.php
@@ -300,5 +300,17 @@ final class StringableInterfaceFixerTest extends AbstractFixerTestCase
             ;
             ',
         ];
+
+        yield ['<?php
+            namespace Foo;
+            use Stringable;
+            class Bar {
+                public function foo() {
+                    new class () implements Stringable {
+                        public function __toString() { return ""; }
+                    };
+                }
+            }
+        '];
     }
 }


### PR DESCRIPTION
Currently, if a class includes an anonymous class (possibly other situations as well) with the `\Stringable` interface, then it is incorrectly flagged as being `\Stringable`.

```php
class Foo /* will have \Stringable added by fixer */ {
    public function bar() {
        return new class() implements \Stringable {
        };
    }
}
```

I don't have a fix, just filing a failing test case for now incase someone else can help out and validate/fix.