### PR TITLE
fix "NoLeadingSlashInGlobalNamespaceFixer"

### DIFF
--- a/src/Fixer/NoLeadingSlashInGlobalNamespaceFixer.php
+++ b/src/Fixer/NoLeadingSlashInGlobalNamespaceFixer.php
@@ -72,6 +72,16 @@ $y = new \Baz();
         if ($tokens[$prevIndex]->isGivenKind(\T_STRING)) {
             return false;
         }
+        
+        $nextIndex = $tokens->getNextMeaningfulToken($index);
+        \assert(\is_int($nextIndex));
+        $nextNextIndex = $tokens->getNextMeaningfulToken($nextIndex);
+        \assert(\is_int($nextNextIndex));
+
+        if ($tokens[$nextNextIndex]->isGivenKind(\T_NS_SEPARATOR)) {
+            return false;
+        }
+        
         if ($tokens[$prevIndex]->isGivenKind([\T_NEW, CT::T_NULLABLE_TYPE, CT::T_TYPE_COLON])) {
             return true;
         }


### PR DESCRIPTION
Using of namespaces in a global namespace should not be break: e.g.: `\Foo\Bar\lall()` vs `Foo\Bar\lall()`