### PR TITLE
StringableInterfaceFixer - add `Stringable` at the beginning of interfaces list to avoid "Class cannot implement previously implemented interface" message

### DIFF
--- a/src/Fixer/StringableInterfaceFixer.php
+++ b/src/Fixer/StringableInterfaceFixer.php
@@ -216,19 +216,16 @@ class Foo
             return;
         }
 
-        $implementsEndIndex = $tokens->getNextTokenOfKind($implementsIndex, ['{']);
-        \assert(\is_int($implementsEndIndex));
-
-        $prevIndex = $tokens->getPrevMeaningfulToken($implementsEndIndex);
-        \assert(\is_int($prevIndex));
+        $afterImplementsIndex = $tokens->getNextMeaningfulToken($implementsIndex);
+        \assert(\is_int($afterImplementsIndex));
 
         $tokens->insertAt(
-            $prevIndex + 1,
+            $afterImplementsIndex,
             [
-                new Token(','),
-                new Token([\T_WHITESPACE, ' ']),
                 new Token([\T_NS_SEPARATOR, '\\']),
                 new Token([\T_STRING, 'Stringable']),
+                new Token(','),
+                new Token([\T_WHITESPACE, ' ']),
             ],
         );
     }

--- a/tests/Fixer/StringableInterfaceFixerTest.php
+++ b/tests/Fixer/StringableInterfaceFixerTest.php
@@ -130,7 +130,7 @@ final class StringableInterfaceFixerTest extends AbstractFixerTestCase
         yield [
             '<?php namespace FooNamespace;
             use Bar\Stringable;
-            class Foo implements Stringable, \Stringable
+            class Foo implements \Stringable, Stringable
             {
                 public function __toString() { return "Foo"; }
             }
@@ -167,13 +167,13 @@ final class StringableInterfaceFixerTest extends AbstractFixerTestCase
 
         foreach ($implementedInterfacesCases as $implementedInterface) {
             yield [
-                \sprintf($template, $implementedInterface . ', \Stringable'),
+                \sprintf($template, '\Stringable, ' . $implementedInterface),
                 \sprintf($template, $implementedInterface),
             ];
         }
 
         yield [
-            '<?php class Foo implements FooInterface, \Stringable
+            '<?php class Foo implements \Stringable, FooInterface
             {
                 public function __toString() { return "Foo"; }
             }
@@ -215,7 +215,7 @@ final class StringableInterfaceFixerTest extends AbstractFixerTestCase
             '<?php
                 namespace Foo;
                 use Bar;
-                class Baz implements Stringable, \Stringable {
+                class Baz implements \Stringable, Stringable {
                     public function __toString() { return ""; }
                 }
             ',
@@ -273,15 +273,17 @@ final class StringableInterfaceFixerTest extends AbstractFixerTestCase
 
         yield [
             '<?php
-                namespace Foo { class C implements I, \Stringable { public function __toString() { return ""; } }}
+                namespace Foo { class C implements \Stringable, I { public function __toString() { return ""; } }}
                 namespace Bar { class C implements \Stringable, I { public function __toString() { return ""; } }}
                 namespace Baz { class C implements I, \Stringable { public function __toString() { return ""; } }}
+                namespace Qux { class C implements \Stringable, I { public function __toString() { return ""; } }}
             ;
             ',
             '<?php
                 namespace Foo { class C implements I { public function __toString() { return ""; } }}
                 namespace Bar { class C implements \Stringable, I { public function __toString() { return ""; } }}
-                namespace Baz { class C implements I { public function __toString() { return ""; } }}
+                namespace Baz { class C implements I, \Stringable { public function __toString() { return ""; } }}
+                namespace Qux { class C implements I { public function __toString() { return ""; } }}
             ;
             ',
         ];
@@ -289,7 +291,7 @@ final class StringableInterfaceFixerTest extends AbstractFixerTestCase
         yield [
             '<?php
                 namespace Foo { use Stringable as Stringy; class C {} }
-                namespace Bar { class C implements Stringy, \Stringable { public function __toString() { return ""; } }}
+                namespace Bar { class C implements \Stringable, Stringy { public function __toString() { return ""; } }}
             ;
             ',
             '<?php

--- a/tests/priority_fixtures/Custom_stringable_interface,class_definition.test
+++ b/tests/priority_fixtures/Custom_stringable_interface,class_definition.test
@@ -2,9 +2,9 @@
 { "PhpCsFixerCustomFixers/stringable_interface": true, "class_definition": true }
 --EXPECTED--
 <?php class Foo implements
+    \Stringable,
     Bar,
-    Baz,
-    \Stringable
+    Baz
 {
     public function __toString() { return "Foo"; }
 }

--- a/tests/priority_fixtures/Custom_stringable_interface,ordered_interfaces.test
+++ b/tests/priority_fixtures/Custom_stringable_interface,ordered_interfaces.test
@@ -1,13 +1,13 @@
 --CONFIGURATION--
 { "PhpCsFixerCustomFixers/stringable_interface": true, "ordered_interfaces": true }
 --EXPECTED--
-<?php class Foo implements \Stringable, Zzz
+<?php class Foo implements \Bar, \Stringable
 {
     public function __toString() { return "Foo"; }
 }
 
 --INPUT--
-<?php class Foo implements Zzz
+<?php class Foo implements \Bar
 {
     public function __toString() { return "Foo"; }
 }


### PR DESCRIPTION
Resolves https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues/923