### PR TITLE
Lock `nikic/php-parser` to ^4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "friendsofphp/php-cs-fixer": "^3.22"
     },
     "require-dev": {
+        "nikic/php-parser": "^4",
         "phpunit/phpunit": "^9.6.4 || ^10.0.14"
     },
     "autoload": {


### PR DESCRIPTION
(to temporarily fix the CI)