### PR TITLE
Keep parentheses around `and`, `xor` and `or`

### DIFF
--- a/src/Fixer/NoUselessParenthesisFixer.php
+++ b/src/Fixer/NoUselessParenthesisFixer.php
@@ -104,6 +104,10 @@ foo(($bar));
             return true;
         }
 
+        if ($this->hasLowPrecedenceLogicOperator($tokens, $startIndex, $endIndex)) {
+            return false;
+        }
+
         return $tokens[$prevStartIndex]->equalsAny(['=', [\T_RETURN], [\T_THROW]]) && $tokens[$nextEndIndex]->equals(';');
     }
 
@@ -174,6 +178,29 @@ foo(($bar));
         }
 
         return true;
+    }
+
+    private function hasLowPrecedenceLogicOperator(Tokens $tokens, int $startIndex, int $endIndex): bool
+    {
+        $index = $tokens->getNextMeaningfulToken($startIndex);
+        \assert(\is_int($index));
+
+        while ($index < $endIndex) {
+            if (
+                $tokens[$index]->isGivenKind([
+                    \T_LOGICAL_XOR,
+                    \T_LOGICAL_AND,
+                    \T_LOGICAL_OR,
+                ])
+            ) {
+                return true;
+            }
+
+            $index = $tokens->getNextMeaningfulToken($index);
+            \assert(\is_int($index));
+        }
+
+        return false;
     }
 
     private function clearWhitespace(Tokens $tokens, int $index): void

--- a/tests/Fixer/NoUselessParenthesisFixerTest.php
+++ b/tests/Fixer/NoUselessParenthesisFixerTest.php
@@ -367,6 +367,19 @@ final class NoUselessParenthesisFixerTest extends AbstractFixerTestCase
                 return (1);
             ',
         ];
+
+        yield ['<?php $test = (true and false);'];
+        yield ['<?php $test = (false xor true);'];
+        yield ['<?php $test = (false or true);'];
+
+        yield [
+            '<?php $test = false || true;',
+            '<?php $test = (false || true);',
+        ];
+        yield [
+            '<?php $test = false && true;',
+            '<?php $test = (false && true);',
+        ];
     }
 
     /**


### PR DESCRIPTION
This PR updates the no_useless_parenthesis fixer, so it preserves parentheses around expressions using `and`, `xor` and `or`. Because of the lower precedence of these operators, the meaning could change when the parentheses are removed (more info [here](https://www.php.net/manual/en/language.operators.logical.php) in the first example).