### PR TITLE
Add option for ignoring different types of quotes (fixes #916)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Latest stable version](https://img.shields.io/packagist/v/kubawerlos/php-cs-fixer-custom-fixers.svg?label=current%20version)](https://packagist.org/packages/kubawerlos/php-cs-fixer-custom-fixers)
 [![PHP version](https://img.shields.io/packagist/php-v/kubawerlos/php-cs-fixer-custom-fixers.svg)](https://php.net)
 [![License](https://img.shields.io/github/license/kubawerlos/php-cs-fixer-custom-fixers.svg)](LICENSE)
-![Tests](https://img.shields.io/badge/tests-3543-brightgreen.svg)
+![Tests](https://img.shields.io/badge/tests-3545-brightgreen.svg)
 [![Downloads](https://img.shields.io/packagist/dt/kubawerlos/php-cs-fixer-custom-fixers.svg)](https://packagist.org/packages/kubawerlos/php-cs-fixer-custom-fixers)
 
 [![CI status](https://github.com/kubawerlos/php-cs-fixer-custom-fixers/actions/workflows/ci.yaml/badge.svg)](https://github.com/kubawerlos/php-cs-fixer-custom-fixers/actions/workflows/ci.yaml)
@@ -313,6 +313,7 @@ There must be no parameters passed by reference in functions.
 There must be no superfluous concatenation of literal strings.
 Configuration options:
 - `allow_preventing_trailing_spaces` (`bool`): whether to keep concatenation if it prevents having trailing spaces in string; defaults to `false`
+- `keep_concatenation_for_different_quotes` (`bool`): whether to keep concatenation if single-quoted and double-quoted would be concatenated; defaults to `false`
 ```diff
  <?php
 -echo 'foo' . 'bar';

--- a/src/Fixer/NoSuperfluousConcatenationFixer.php
+++ b/src/Fixer/NoSuperfluousConcatenationFixer.php
@@ -25,6 +25,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class NoSuperfluousConcatenationFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
     private bool $allowPreventingTrailingSpaces = false;
+    private bool $keepConcatenationForDifferentQuotes = false;
 
     public function getDefinition(): FixerDefinitionInterface
     {
@@ -42,6 +43,10 @@ final class NoSuperfluousConcatenationFixer extends AbstractFixer implements Con
                 ->setAllowedTypes(['bool'])
                 ->setDefault($this->allowPreventingTrailingSpaces)
                 ->getOption(),
+            (new FixerOptionBuilder('keep_concatenation_for_different_quotes', 'whether to keep concatenation if single-quoted and double-quoted would be concatenated'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault($this->keepConcatenationForDifferentQuotes)
+                ->getOption(),
         ]);
     }
 
@@ -52,6 +57,9 @@ final class NoSuperfluousConcatenationFixer extends AbstractFixer implements Con
     {
         if (\array_key_exists('allow_preventing_trailing_spaces', $configuration)) {
             $this->allowPreventingTrailingSpaces = $configuration['allow_preventing_trailing_spaces'];
+        }
+        if (\array_key_exists('keep_concatenation_for_different_quotes', $configuration)) {
+            $this->keepConcatenationForDifferentQuotes = $configuration['keep_concatenation_for_different_quotes'];
         }
     }
 
@@ -97,6 +105,12 @@ final class NoSuperfluousConcatenationFixer extends AbstractFixer implements Con
                 continue;
             }
             if (!$this->areOnlyHorizontalWhitespacesBetween($tokens, $index, $secondIndex)) {
+                continue;
+            }
+            if (
+                $this->keepConcatenationForDifferentQuotes
+                && substr($tokens[$firstIndex]->getContent(), 0, 1) !== substr($tokens[$secondIndex]->getContent(), 0, 1)
+            ) {
                 continue;
             }
 

--- a/tests/Fixer/NoSuperfluousConcatenationFixerTest.php
+++ b/tests/Fixer/NoSuperfluousConcatenationFixerTest.php
@@ -186,6 +186,12 @@ final class NoSuperfluousConcatenationFixerTest extends AbstractFixerTestCase
             ['allow_preventing_trailing_spaces' => true],
         ];
 
+        yield 'option for leaving double-quoted string and single-quoted string concatendated' => [
+            '\'abc\'."def"',
+            null,
+            ['keep_concatenation_for_different_quotes' => true]
+        ];
+
         yield 'dollar as last character in double quotes merged with double quotes' => [
             '"My name is \\$foo"',
             '"My name is $" . "foo"',


### PR DESCRIPTION
As described in https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues/916, a concatenation of single-quoted and double-quoted strings can be intentional to reduce quote escaping in the code.

This PR introduces a setting `keep_concatenation_for_different_quotes` which allows keeping such concatenations.