### PR TITLE
Bump php-cs-fixer to 3.57 (parallel runners)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.4 || ^8.0",
         "ext-filter": "*",
         "ext-tokenizer": "*",
-        "friendsofphp/php-cs-fixer": "^3.50"
+        "friendsofphp/php-cs-fixer": "^3.57"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.4 || ^10.0.14"


### PR DESCRIPTION
This update add support for php-cs-fixer 3.57 (support for parallel runners)