### PR TITLE
fix: `PhpdocVarAnnotationToAssertFixer` - do not convert types from `phpstan-type`, `phpstan-import-type`, `psalm-type` and `psalm-import-type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG for PHP CS Fixer: custom fixers
 
+## v3.31.0
+- Update minimum PHP CS Fixer version to 3.83.0
+
 ## v3.30.0
 - Update minimum PHP CS Fixer version to 3.82.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG for PHP CS Fixer: custom fixers
 
 ## v3.31.0
-- Update minimum PHP CS Fixer version to 3.83.0
+- Update minimum PHP CS Fixer version to 3.84.0
 
 ## v3.30.0
 - Update minimum PHP CS Fixer version to 3.82.0

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.4 || ^8.0",
         "ext-filter": "*",
         "ext-tokenizer": "*",
-        "friendsofphp/php-cs-fixer": "^3.83"
+        "friendsofphp/php-cs-fixer": "^3.84"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.22 || 10.5.45 || ^11.5.7"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.4 || ^8.0",
         "ext-filter": "*",
         "ext-tokenizer": "*",
-        "friendsofphp/php-cs-fixer": "^3.82"
+        "friendsofphp/php-cs-fixer": "^3.83"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.22 || 10.5.45 || ^11.5.7"

--- a/tests/Fixer/PhpdocVarAnnotationToAssertFixerTest.php
+++ b/tests/Fixer/PhpdocVarAnnotationToAssertFixerTest.php
@@ -399,5 +399,167 @@ final class PhpdocVarAnnotationToAssertFixerTest extends AbstractFixerTestCase
                 $z = 4;
             ',
         ];
+
+        yield 'types defined with `phpstan-type`' => [
+            <<<'PHP'
+                <?php
+                /**
+                 * @phpstan-type _Pair array{int, int}
+                 */
+                class Foo {
+                    public function bar() {
+                        /** @var _Pair $x */
+                        $x = getValue();
+                    }
+                }
+                /**
+                 * @phpstan-type _Trio array{int, int, int}
+                 */
+                class Bar {
+                    public function bar() {
+                        /** @var _Trio $x */
+                        $x = getValue();
+                    }
+                }
+                PHP,
+        ];
+
+        yield 'types defined with `phpstan-import-type`' => [
+            <<<'PHP'
+                <?php
+                /**
+                 * @phpstan-import-type _Pair from FooFoo
+                 */
+                class Foo {
+                    public function bar() {
+                        /** @var _Pair $x */
+                        $x = getValue();
+                    }
+                }
+                /**
+                 * @phpstan-import-type _Trio from BarBar
+                 */
+                class Bar {
+                    public function bar() {
+                        /** @var _Trio $x */
+                        $x = getValue();
+                    }
+                }
+                PHP,
+        ];
+
+        yield 'types defined with `phpstan-import-type` with alias' => [
+            <<<'PHP'
+                <?php
+                /**
+                 * @phpstan-import-type ConflictingType from FooFoo as Not_ConflictingType
+                 */
+                class Foo {
+                    public function bar() {
+                        $x = getValue();
+                        assert($x instanceof ConflictingType);
+
+                        /** @var Not_ConflictingType $y */
+                        $y = getValue();
+                    }
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                /**
+                 * @phpstan-import-type ConflictingType from FooFoo as Not_ConflictingType
+                 */
+                class Foo {
+                    public function bar() {
+                        /** @var ConflictingType $x */
+                        $x = getValue();
+
+                        /** @var Not_ConflictingType $y */
+                        $y = getValue();
+                    }
+                }
+                PHP,
+        ];
+
+        yield 'types defined with `psalm-type`' => [
+            <<<'PHP'
+                <?php
+                /**
+                 * @psalm-type _Pair = array{int, int}
+                 */
+                class Foo {
+                    public function bar() {
+                        /** @var _Pair $x */
+                        $x = getValue();
+                    }
+                }
+                /**
+                 * @psalm-type _Trio array{int, int, int}
+                 */
+                class Bar {
+                    public function bar() {
+                        /** @var _Trio $x */
+                        $x = getValue();
+                    }
+                }
+                PHP,
+        ];
+
+        yield 'types defined with `psalm-import-type`' => [
+            <<<'PHP'
+                <?php
+                /**
+                 * @psalm-import-type _Pair from FooFoo
+                 */
+                class Foo {
+                    public function bar() {
+                        /** @var _Pair $x */
+                        $x = getValue();
+                    }
+                }
+                /**
+                 * @psalm-import-type _Trio from BarBar
+                 */
+                class Bar {
+                    public function bar() {
+                        /** @var _Trio $x */
+                        $x = getValue();
+                    }
+                }
+                PHP,
+        ];
+
+        yield 'types defined with `psalm-import-type` with alias' => [
+            <<<'PHP'
+                <?php
+                /**
+                 * @psalm-import-type Bar from FooFoo as BarAliased
+                 */
+                class Foo {
+                    public function bar() {
+                        $x = getValue();
+                        assert($x instanceof Bar);
+
+                        /** @var BarAliased $y */
+                        $y = getValue();
+                    }
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                /**
+                 * @psalm-import-type Bar from FooFoo as BarAliased
+                 */
+                class Foo {
+                    public function bar() {
+                        /** @var Bar $x */
+                        $x = getValue();
+
+                        /** @var BarAliased $y */
+                        $y = getValue();
+                    }
+                }
+                PHP,
+        ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues/1056