### PR TITLE
`PhpdocTypesCommaSpacesFixer` and `PhpdocTypesTrimFixer` - fix for multiline PHPDocs

### DIFF
--- a/tests/Fixer/PhpdocTypesCommaSpacesFixerTest.php
+++ b/tests/Fixer/PhpdocTypesCommaSpacesFixerTest.php
@@ -105,5 +105,26 @@ final class PhpdocTypesCommaSpacesFixerTest extends AbstractFixerTestCase
                     * @return array<string,Foo> Description having "," should not be touched
                     */',
         ];
+
+        yield [
+            <<<'PHP'
+                <?php
+                /**
+                 * @return array{
+                 *     foo: bool,
+                 *     bar: null|string,
+                 *  }
+                 */
+                PHP,
+            <<<'PHP'
+                <?php
+                /**
+                 * @return array{
+                 *     foo: bool         ,
+                 *     bar: null|string  ,
+                 *  }
+                 */
+                PHP,
+        ];
     }
 }

--- a/tests/Fixer/PhpdocTypesTrimFixerTest.php
+++ b/tests/Fixer/PhpdocTypesTrimFixerTest.php
@@ -257,5 +257,26 @@ final class PhpdocTypesTrimFixerTest extends AbstractFixerTestCase
                  function baz() {}
              ',
         ];
+
+        yield [
+            <<<'PHP'
+                <?php
+                /**
+                 * @return array{
+                 *     foo: null|bool,
+                 *     bar: string|null,
+                 *  }
+                 */
+                PHP,
+            <<<'PHP'
+                <?php
+                /**
+                 * @return array{
+                 *     foo: null | bool,
+                 *     bar: string    |    null,
+                 *  }
+                 */
+                PHP,
+        ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues/1069