### PR TITLE
Rename `PhpDocPropertySorterFixer` to `PhpdocPropertySortedFixer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG for PHP CS Fixer: custom fixers
 
+## v3.34.0
+- Add PhpdocPropertySortedFixer
+
 ## v3.33.0
 - Add PhpDocPropertySorterFixer
 - Deprecate PhpdocTagNoNamedArgumentsFixer - use "phpdoc_tag_no_named_arguments"

--- a/README.md
+++ b/README.md
@@ -461,19 +461,6 @@ Configuration options:
 +echo 01234567; // octal
 ```
 
-#### PhpDocPropertySorterFixer
-Sorts @property annotations in PHPDoc blocks alphabetically within groups separated by empty lines.
-```diff
- <?php
- /**
-- * @property string $zzz
-  * @property int $aaa
-  * @property bool $mmm
-+ * @property string $zzz
-  */
- class Foo {}
-```
-
 #### PhpUnitAssertArgumentsOrderFixer
 PHPUnit assertions must have expected argument before actual one.
   *Risky: when original PHPUnit methods are overwritten.*
@@ -613,6 +600,19 @@ The `@param` annotations must have a type.
 + * @param mixed  $bar
   */
  function a($foo, $bar) {}
+```
+
+#### PhpdocPropertySortedFixer
+Sorts @property annotations in PHPDoc blocks alphabetically within groups separated by empty lines.
+```diff
+ <?php
+ /**
+- * @property string $zzz
+  * @property int $aaa
+  * @property bool $mmm
++ * @property string $zzz
+  */
+ class Foo {}
 ```
 
 #### PhpdocSelfAccessorFixer

--- a/src/Fixer/PhpdocPropertySortedFixer.php
+++ b/src/Fixer/PhpdocPropertySortedFixer.php
@@ -21,7 +21,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @no-named-arguments
  */
-final class PhpDocPropertySorterFixer extends AbstractFixer
+final class PhpdocPropertySortedFixer extends AbstractFixer
 {
     public function getDefinition(): FixerDefinitionInterface
     {

--- a/tests/Fixer/PhpdocPropertySortedFixerTest.php
+++ b/tests/Fixer/PhpdocPropertySortedFixerTest.php
@@ -14,9 +14,9 @@ namespace Tests\Fixer;
 /**
  * @internal
  *
- * @covers \PhpCsFixerCustomFixers\Fixer\PhpDocPropertySorterFixer
+ * @covers \PhpCsFixerCustomFixers\Fixer\PhpdocPropertySortedFixer
  */
-final class PhpDocPropertySorterFixerTest extends AbstractFixerTestCase
+final class PhpdocPropertySortedFixerTest extends AbstractFixerTestCase
 {
     public function testIsRisky(): void
     {


### PR DESCRIPTION
All fixers (here and in the main repo) are having lowercase `d` in `Phpdoc`.
Also, the naming convention is to name the fixer as what is done after fixing, not what it is doing (e.g. `ordered_imports`).

I will add `PhpDocPropertySorterFixer` as deprecated in a separate PR, to not lose the authorship history in Git.