### PR TITLE
Add `PhpDocPropertySorterFixer` back as deprecated to keep BC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v3.34.0
 - Add PhpdocPropertySortedFixer
+- Deprecate PhpDocPropertySorterFixer - use PhpdocPropertySortedFixer
 
 ## v3.33.0
 - Add PhpDocPropertySorterFixer

--- a/README.md
+++ b/README.md
@@ -461,6 +461,20 @@ Configuration options:
 +echo 01234567; // octal
 ```
 
+#### PhpDocPropertySorterFixer
+Sorts @property annotations in PHPDoc blocks alphabetically within groups separated by empty lines.
+  DEPRECATED: use `PhpCsFixerCustomFixers/phpdoc_property_sorted` instead.
+```diff
+ <?php
+ /**
+- * @property string $zzz
+  * @property int $aaa
+  * @property bool $mmm
++ * @property string $zzz
+  */
+ class Foo {}
+```
+
 #### PhpUnitAssertArgumentsOrderFixer
 PHPUnit assertions must have expected argument before actual one.
   *Risky: when original PHPUnit methods are overwritten.*

--- a/src/Fixer/PhpDocPropertySorterFixer.php
+++ b/src/Fixer/PhpDocPropertySorterFixer.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer: custom fixers.
+ *
+ * (c) 2018 Kuba Werłos
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCsFixerCustomFixers\Fixer;
+
+use PhpCsFixer\Fixer\DeprecatedFixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @deprecated
+ *
+ * @no-named-arguments
+ */
+final class PhpDocPropertySorterFixer extends AbstractFixer implements DeprecatedFixerInterface
+{
+    private PhpdocPropertySortedFixer $phpdocPropertySortedFixer;
+
+    public function __construct()
+    {
+        $this->phpdocPropertySortedFixer = new PhpdocPropertySortedFixer();
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return $this->phpdocPropertySortedFixer->getDefinition();
+    }
+
+    public function getPriority(): int
+    {
+        return $this->phpdocPropertySortedFixer->getPriority();
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $this->phpdocPropertySortedFixer->isCandidate($tokens);
+    }
+
+    public function isRisky(): bool
+    {
+        return $this->phpdocPropertySortedFixer->isRisky();
+    }
+
+    public function fix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $this->phpdocPropertySortedFixer->fix($file, $tokens);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSuccessorsNames(): array
+    {
+        return [$this->phpdocPropertySortedFixer->getName()];
+    }
+}

--- a/tests/Fixer/PhpDocPropertySorterFixerTest.php
+++ b/tests/Fixer/PhpDocPropertySorterFixerTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer: custom fixers.
+ *
+ * (c) 2018 Kuba Werłos
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Fixer;
+
+use PhpCsFixerCustomFixers\Fixer\PhpdocPropertySortedFixer;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixerCustomFixers\Fixer\PhpDocPropertySorterFixer
+ */
+final class PhpDocPropertySorterFixerTest extends AbstractFixerTestCase
+{
+    public function testSuccessorName(): void
+    {
+        self::assertSuccessorName(PhpdocPropertySortedFixer::name());
+    }
+
+    public function testIsRisky(): void
+    {
+        self::assertRiskiness(false);
+    }
+
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1?: string}>
+     */
+    public static function provideFixCases(): iterable
+    {
+        yield from PhpdocPropertySortedFixerTest::provideFixCases();
+    }
+}


### PR DESCRIPTION
Follow up to https://github.com/kubawerlos/php-cs-fixer-custom-fixers/pull/1090