### PR TITLE
`PhpdocNoIncorrectVarAnnotationFixer` - keep string literals

### DIFF
--- a/src/Fixer/PhpdocNoIncorrectVarAnnotationFixer.php
+++ b/src/Fixer/PhpdocNoIncorrectVarAnnotationFixer.php
@@ -65,7 +65,7 @@ $bar = new Foo();
             }
 
             // remove ones not having type at the beginning
-            self::removeVarAnnotationNotMatchingPattern($tokens, $index, '/@var\\s+[\\?\\\\a-zA-Z_\\x7f-\\xff]/');
+            self::removeVarAnnotationNotMatchingPattern($tokens, $index, '/@var\\s+[\\?\\\\a-zA-Z_\\x7f-\\xff\'"]/');
 
             $nextIndex = self::getIndexAfterPhpDoc($tokens, $index);
 

--- a/tests/Fixer/PhpdocNoIncorrectVarAnnotationFixerTest.php
+++ b/tests/Fixer/PhpdocNoIncorrectVarAnnotationFixerTest.php
@@ -257,6 +257,33 @@ class Foo
             }',
         ];
 
+        yield 'keep string literals' => [
+            <<<'PHP'
+                <?php class Foo
+                {
+                    /**
+                     * @var 'foo'
+                     */
+                    public string $a;
+
+                    /**
+                     * @var 'foo'|'bar'|'baz'
+                     */
+                    protected string $b;
+
+                    /**
+                     * @var 'foo'|'foo-with-dashes'|'bar'|'baz'|null
+                     */
+                    private ?string $c;
+
+                    /**
+                     * @var "in-double-quotes"|null
+                     */
+                    public ?string $d;
+                }
+                PHP,
+        ];
+
         yield 'remove PHPDoc for class properties' => [
             '<?php
 class Foo


### PR DESCRIPTION
Fixes https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues/1094