### PR TITLE
Add `dd`, `dump`, `d` as default functions for `CommentedOutFunctionFixer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Comments must be surrounded by spaces.
 The configured functions must be commented out.
   *Risky: when any of the configured functions have side effects or are overwritten.*
 Configuration options:
-- `functions` (`array`): list of functions to comment out; defaults to `['print_r', 'var_dump', 'var_export']`
+- `functions` (`array`): list of functions to comment out; defaults to `['print_r', 'var_dump', 'var_export', 'dd', 'dump', 'd']`
 ```diff
  <?php
 -var_dump($x);

--- a/src/Fixer/CommentedOutFunctionFixer.php
+++ b/src/Fixer/CommentedOutFunctionFixer.php
@@ -35,7 +35,7 @@ use PhpCsFixerCustomFixers\Analyzer\SwitchAnalyzer;
 final class CommentedOutFunctionFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
     /** @var list<string> */
-    private array $functions = ['print_r', 'var_dump', 'var_export'];
+    private array $functions = ['print_r', 'var_dump', 'var_export', 'dd', 'dump', 'd'];
 
     public function getDefinition(): FixerDefinitionInterface
     {

--- a/tests/Fixer/CommentedOutFunctionFixerTest.php
+++ b/tests/Fixer/CommentedOutFunctionFixerTest.php
@@ -223,13 +223,28 @@ baz();
 //                var_dump($x);
                 print_r($x, true) . " is input";
                 "Result: " . print_r($y, true);
-//                var_dump($y);
+//                dd($y);
             ',
             '<?php
                 var_dump($x);
                 print_r($x, true) . " is input";
                 "Result: " . print_r($y, true);
-                var_dump($y);
+                dd($y);
+            ',
+        ];
+
+        yield 'complex with other default functions' => [
+            '<?php
+//                dump($x);
+                print_r($x, true) . " is input";
+                "Result: " . print_r($y, true);
+//                d($y);
+            ',
+            '<?php
+                dump($x);
+                print_r($x, true) . " is input";
+                "Result: " . print_r($y, true);
+                d($y);
             ',
         ];
     }


### PR DESCRIPTION
Fixes https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues/1100