### PR TITLE
`PhpdocNoIncorrectVarAnnotationFixer` - do not remove PHPDoc when there are parentheses

### DIFF
--- a/src/Fixer/PhpdocNoIncorrectVarAnnotationFixer.php
+++ b/src/Fixer/PhpdocNoIncorrectVarAnnotationFixer.php
@@ -65,7 +65,7 @@ $bar = new Foo();
             }
 
             // remove ones not having type at the beginning
-            self::removeVarAnnotationNotMatchingPattern($tokens, $index, '/@var\\s+[\\?\\\\a-zA-Z_\\x7f-\\xff\'"]/');
+            self::removeVarAnnotationNotMatchingPattern($tokens, $index, '/@var\\s+[\\?\\\\a-zA-Z_\\x7f-\\xff\'"()]/');
 
             $nextIndex = self::getIndexAfterPhpDoc($tokens, $index);
 

--- a/tests/Fixer/PhpdocNoIncorrectVarAnnotationFixerTest.php
+++ b/tests/Fixer/PhpdocNoIncorrectVarAnnotationFixerTest.php
@@ -206,6 +206,11 @@ class Foo
     static $a;
 
     /**
+     * @var (self|DateTime)[]
+     */
+    public array $parentheses;
+
+    /**
      * @var int
      */
     public $b;


### PR DESCRIPTION
…re are parantheses

Resolves: #1132