### PR TITLE
`PhpdocNoIncorrectVarAnnotationFixer` - fix for PHPDoc for asymmetric-visibility properties

### DIFF
--- a/src/Fixer/PhpdocNoIncorrectVarAnnotationFixer.php
+++ b/src/Fixer/PhpdocNoIncorrectVarAnnotationFixer.php
@@ -74,7 +74,7 @@ $bar = new Foo();
                 continue;
             }
 
-            if ($tokens[$nextIndex]->isGivenKind([\T_PRIVATE, \T_PROTECTED, \T_PUBLIC, \T_VAR, \T_STATIC, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE])) {
+            if ($tokens[$nextIndex]->isGivenKind([\T_PRIVATE, \T_PROTECTED, \T_PUBLIC, \T_VAR, \T_STATIC, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE, FCT::T_PUBLIC_SET, FCT::T_PROTECTED_SET, FCT::T_PRIVATE_SET])) {
                 self::removeForClassElement($tokens, $index, $nextIndex);
                 continue;
             }
@@ -107,7 +107,7 @@ $bar = new Foo();
 
     private static function removeForClassElement(Tokens $tokens, int $index, int $propertyStartIndex): void
     {
-        $variableIndex = $tokens->getTokenNotOfKindsSibling($propertyStartIndex, 1, [\T_NS_SEPARATOR, \T_STATIC, \T_STRING, \T_WHITESPACE, CT::T_ARRAY_TYPEHINT, CT::T_NULLABLE_TYPE, CT::T_TYPE_ALTERNATION, CT::T_TYPE_INTERSECTION, FCT::T_READONLY]);
+        $variableIndex = $tokens->getTokenNotOfKindsSibling($propertyStartIndex, 1, [\T_NS_SEPARATOR, \T_STATIC, \T_STRING, \T_WHITESPACE, CT::T_ARRAY_TYPEHINT, CT::T_NULLABLE_TYPE, CT::T_TYPE_ALTERNATION, CT::T_TYPE_INTERSECTION, FCT::T_READONLY, FCT::T_PUBLIC_SET, FCT::T_PROTECTED_SET, FCT::T_PRIVATE_SET]);
         \assert(\is_int($variableIndex));
 
         if (!$tokens[$variableIndex]->isGivenKind(\T_VARIABLE)) {

--- a/tests/Fixer/PhpdocNoIncorrectVarAnnotationFixerTest.php
+++ b/tests/Fixer/PhpdocNoIncorrectVarAnnotationFixerTest.php
@@ -555,49 +555,33 @@ $x = 0;
     public static function provideFix84Cases(): iterable
     {
         yield 'keep correct PHPDoc for asymmetric-visibility properties' => [
-            '<?php final class ArrayLogger
-                {
-                    /**
-                     */
-                    public private(set) array $a = [];
+            <<<'PHP'
+                <?php final class ArrayLogger
+                    {
+                        /**
+                         * @var list<string>
+                         */
+                        public private(set) array $a = [];
 
-                    public protected(set) array $b = [];
+                        /** @var array<string> */
+                        public protected(set) array $b = [];
 
-                    protected private(set) int $c = 0;
+                        /** @var int<0, max> */
+                        protected private(set) int $c = 0;
 
-                    private(set) string $d = "d";
+                        /** @var non-empty-string */
+                        private(set) string $d = "d";
 
-                    protected(set) string $e = "e";
+                        /** @var non-empty-string */
+                        protected(set) string $e = "e";
 
-                    public(set) string $f = "f";
+                        /** @var non-empty-string */
+                        public(set) string $f = "f";
 
-                    public public(set) array $g = [];
-                }',
-            '<?php final class ArrayLogger
-                {
-                    /**
-                     * @var list<string>
-                     */
-                    public private(set) array $a = [];
-
-                    /** @var array<string> */
-                    public protected(set) array $b = [];
-
-                    /** @var int<0, max> */
-                    protected private(set) int $c = 0;
-
-                    /** @var non-empty-string */
-                    private(set) string $d = "d";
-
-                    /** @var non-empty-string */
-                    protected(set) string $e = "e";
-
-                    /** @var non-empty-string */
-                    public(set) string $f = "f";
-
-                    /** @var list<int> */
-                    public public(set) array $g = [];
-                }',
+                        /** @var list<int> */
+                        public public(set) array $g = [];
+                    }
+                PHP,
         ];
     }
 }

--- a/tests/Fixer/PhpdocNoIncorrectVarAnnotationFixerTest.php
+++ b/tests/Fixer/PhpdocNoIncorrectVarAnnotationFixerTest.php
@@ -538,4 +538,66 @@ $x = 0;
                 }',
         ];
     }
+
+    /**
+     * @dataProvider provideFix84Cases
+     *
+     * @requires PHP >= 8.4.0
+     */
+    public function testFix84(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1?: string}>
+     */
+    public static function provideFix84Cases(): iterable
+    {
+        yield 'keep correct PHPDoc for asymmetric-visibility properties' => [
+            '<?php final class ArrayLogger
+                {
+                    /**
+                     */
+                    public private(set) array $a = [];
+
+                    public protected(set) array $b = [];
+
+                    protected private(set) int $c = 0;
+
+                    private(set) string $d = "d";
+
+                    protected(set) string $e = "e";
+
+                    public(set) string $f = "f";
+
+                    public public(set) array $g = [];
+                }',
+            '<?php final class ArrayLogger
+                {
+                    /**
+                     * @var list<string>
+                     */
+                    public private(set) array $a = [];
+
+                    /** @var array<string> */
+                    public protected(set) array $b = [];
+
+                    /** @var int<0, max> */
+                    protected private(set) int $c = 0;
+
+                    /** @var non-empty-string */
+                    private(set) string $d = "d";
+
+                    /** @var non-empty-string */
+                    protected(set) string $e = "e";
+
+                    /** @var non-empty-string */
+                    public(set) string $f = "f";
+
+                    /** @var list<int> */
+                    public public(set) array $g = [];
+                }',
+        ];
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues/1140